### PR TITLE
Add GitHub Actions CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build
+
+on: [push]
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    steps:
+
+    # Free disk space to be able to clone the upstream repo.
+    - name: Free disk space
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: true
+        android: false
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
+    # Checkout the repository.
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Install the prerequisites.
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install repo
+
+    # Build the boot image.
+    - name: Build TWRP
+      run: ./bootstrap.sh
+
+    # Upload the boot image as a short-lived artifact.
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        path: out/target/product/FP5/boot.img
+        name: twrp-fp5-boot.img
+        retention-days: 1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -xe
+
+# Initialize the TWRP repository.
+repo init \
+  --depth=1 \
+  --manifest-url=https://github.com/minimal-manifest-twrp/platform_manifest_twrp_aosp.git \
+  --manifest-branch=twrp-12.1
+
+# Add a new local manifest.
+mkdir -p .repo/local_manifests
+cat <<- EOF > .repo/local_manifests/roomservice.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project
+    name="Fairphone/android_device_fairphone_FP5"
+    path="device/fairphone/FP5"
+    remote="github"
+    revision="android-12.1"
+  />
+</manifest>
+EOF
+
+# Sync the repo.
+repo sync
+
+# Remove superfluous makefile.
+rm -f Android.mk
+
+# Compile TWRP.
+export ALLOW_MISSING_DEPENDENCIES=true
+. build/envsetup.sh
+lunch twrp_FP5-eng
+m bootimage


### PR DESCRIPTION
In order to set up a repeatable firmware build, I created a GitHub Actions workflow to compile the firmware inside a clean VM on every push. The build steps are copied directly from the project's README.

However, the CI build is failing with the following error:

```
FAILED: 
In file included from build/make/core/main.mk:543:
In file included from out/soong/Android-twrp_FP5.mk:449669:
In file included from build/make/core/soong_cc_prebuilt.mk:49:
build/make/core/base_rules.mk:335: error: device/fairphone/FP5/bootctrl: MODULE.TARGET.STATIC_LIBRARIES.bootctrl.lahaina already defined by bootctrl.
```

Any idea what could be causing this?

With GitHub Actions, it's also possible to autogenerate release images whenever a tag is pushed. I didn't implement that yet, but it's easy to add if you're interested.